### PR TITLE
Ratatoskr

### DIFF
--- a/src/midgard_connection.c
+++ b/src/midgard_connection.c
@@ -721,8 +721,10 @@ midgard_connection_open (MidgardConnection *self, const char *name, GError **err
 		rv = FALSE;
 	}
 
-	g_hash_table_destroy(hash);
-	
+	if (hash) {
+		g_hash_table_destroy(hash);
+	}
+
 	return rv;
 }
 


### PR DESCRIPTION
simple workaround for "GLib-CRITICAL **: g_hash_table_destroy: assertion `hash_table != NULL' failed" error
