### PR TITLE
Cachedir typo

### DIFF
--- a/src/midgard_config.c
+++ b/src/midgard_config.c
@@ -329,7 +329,7 @@ static void __set_config_from_keyfile(MidgardConfig *self, GKeyFile *keyfile, co
 	}
 
 	/* CacheDir */
-	tmpstr = g_key_file_get_string (keyfile, "MidgardDir", "ShareDir", NULL);
+	tmpstr = g_key_file_get_string (keyfile, "MidgardDir", "CacheDir", NULL);
 	if(tmpstr != NULL || (tmpstr && *tmpstr == '\0')) {
 
 		g_free (self->cachedir);


### PR DESCRIPTION
midgard core filled config->cachedir using ShareDir variable from configuration file.

this is a minor fix, can easily wait for the next release
