### PR TITLE
Tests tuning

### DIFF
--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -9,25 +9,28 @@ MIDGARD_TEST_DB_PASS="midgard_test"
 
 # ./autogen.sh
 
-echo "Preparing temporary database for generic tests…"
-echo "-> sudo mysqladmin create midgard_test"
-sudo mysql -e "CREATE DATABASE ${MIDGARD_TEST_DB} CHARACTER SET utf8";
-echo "-> GRANT all ON ${MIDGARD_TEST_DB}.*  to '${MIDGARD_TEST_DB_USER}'@'localhost' identified by '${MIDGARD_TEST_DB_PASS}'";
-sudo mysql -e "GRANT all ON ${MIDGARD_TEST_DB}.*  to '${MIDGARD_TEST_DB_USER}'@'localhost' identified by '${MIDGARD_TEST_DB_PASS}'";
-sudo mysql -e " FLUSH PRIVILEGES";
+if [ "$MIDGARD_TEST_DATABASE_TYPE" != "SQLite" ]
+then
+    echo "Preparing temporary database for generic tests…"
+    echo "-> sudo mysqladmin create midgard_test"
+    sudo mysql -e "CREATE DATABASE ${MIDGARD_TEST_DB} CHARACTER SET utf8";
+    echo "-> GRANT all ON ${MIDGARD_TEST_DB}.*  to '${MIDGARD_TEST_DB_USER}'@'localhost' identified by '${MIDGARD_TEST_DB_PASS}'";
+    sudo mysql -e "GRANT all ON ${MIDGARD_TEST_DB}.*  to '${MIDGARD_TEST_DB_USER}'@'localhost' identified by '${MIDGARD_TEST_DB_PASS}'";
+    sudo mysql -e " FLUSH PRIVILEGES";
 
-echo "Preparing temporary database for provider test…"
-echo "-> sudo mysqladmin create midgard_test_database_provider"
-sudo mysql -e "CREATE DATABASE ${MIDGARD_TEST_DB_PROVIDER} CHARACTER SET utf8";
-echo "-> GRANT all ON ${MIDGARD_TEST_DB_PROVIDER}.*  to '${MIDGARD_TEST_DB_USER}'@'localhost' identified by '${MIDGARD_TEST_DB_PASS}'";
-sudo mysql -e "GRANT all ON ${MIDGARD_TEST_DB_PROVIDER}.*  to '${MIDGARD_TEST_DB_USER}'@'localhost' identified by '${MIDGARD_TEST_DB_PASS}'";
-sudo mysql -e " FLUSH PRIVILEGES";
+    echo "Preparing temporary database for provider test…"
+    echo "-> sudo mysqladmin create midgard_test_database_provider"
+    sudo mysql -e "CREATE DATABASE ${MIDGARD_TEST_DB_PROVIDER} CHARACTER SET utf8";
+    echo "-> GRANT all ON ${MIDGARD_TEST_DB_PROVIDER}.*  to '${MIDGARD_TEST_DB_USER}'@'localhost' identified by '${MIDGARD_TEST_DB_PASS}'";
+    sudo mysql -e "GRANT all ON ${MIDGARD_TEST_DB_PROVIDER}.*  to '${MIDGARD_TEST_DB_USER}'@'localhost' identified by '${MIDGARD_TEST_DB_PASS}'";
+    sudo mysql -e " FLUSH PRIVILEGES";
 
-echo "-> sudo mysqladmin create midgard_test_replicator_import"
-sudo mysql -e "CREATE DATABASE ${MIDGARD_TEST_DB_REPLICATOR_IMPORT} CHARACTER SET utf8";
-echo "-> GRANT all ON ${MIDGARD_TEST_DB_REPLICATOR_IMPORT}.*  to '${MIDGARD_TEST_DB_USER}'@'localhost' identified by '${MIDGARD_TEST_DB_PASS}'";
-sudo mysql -e "GRANT all ON ${MIDGARD_TEST_DB_REPLICATOR_IMPORT}.*  to '${MIDGARD_TEST_DB_USER}'@'localhost' identified by '${MIDGARD_TEST_DB_PASS}'";
-sudo mysql -e " FLUSH PRIVILEGES";
+    echo "-> sudo mysqladmin create midgard_test_replicator_import"
+    sudo mysql -e "CREATE DATABASE ${MIDGARD_TEST_DB_REPLICATOR_IMPORT} CHARACTER SET utf8";
+    echo "-> GRANT all ON ${MIDGARD_TEST_DB_REPLICATOR_IMPORT}.*  to '${MIDGARD_TEST_DB_USER}'@'localhost' identified by '${MIDGARD_TEST_DB_PASS}'";
+    sudo mysql -e "GRANT all ON ${MIDGARD_TEST_DB_REPLICATOR_IMPORT}.*  to '${MIDGARD_TEST_DB_USER}'@'localhost' identified by '${MIDGARD_TEST_DB_PASS}'";
+    sudo mysql -e " FLUSH PRIVILEGES";
+fi
 
 # Clean files
 rm -f midgard-test.html
@@ -44,15 +47,22 @@ gtester -k -o midgard-test.xml \
 	./run-midgard-test-database-provider \
 	# ./run-midgard-test-replicator-import
 
+
 echo "\nCleanup…"
-echo "-> Droping database midgard_test"
-sudo mysqladmin -f drop midgard_test > /dev/null 2> /dev/null
+if [ "$MIDGARD_TEST_DATABASE_TYPE" == "SQLite" ]
+then
+    echo "-> Deleting sqlite database file"
+    rm -f ~/.midgard2/data/${MIDGARD_TEST_DB}.db
+else
+    echo "-> Droping database midgard_test"
+    sudo mysqladmin -f drop midgard_test > /dev/null 2> /dev/null
 
-echo "-> Droping database midgard_test_replicator_import"
-sudo mysqladmin -f drop midgard_test_replicator_import > /dev/null 2> /dev/null
+    echo "-> Droping database midgard_test_replicator_import"
+    sudo mysqladmin -f drop midgard_test_replicator_import > /dev/null 2> /dev/null
 
-echo "-> Droping database midgard_test_database_provider"
-sudo mysqladmin -f drop midgard_test_database_provider > /dev/null 2> /dev/null
+    echo "-> Droping database midgard_test_database_provider"
+    sudo mysqladmin -f drop midgard_test_database_provider > /dev/null 2> /dev/null
+fi
 
 echo "\nGenerating report… "
 gtester-report midgard-test.xml > midgard-test.html


### PR DESCRIPTION
tuned test-runner, so that it can be used without MySQL using this command:

```
MIDGARD_TEST_DATABASE_TYPE=SQLite ./run_all_tests.sh
```
