### PR TITLE
remove GDA 4 condition for include in midgard_connection.c

### DIFF
--- a/src/midgard_connection.c
+++ b/src/midgard_connection.c
@@ -29,10 +29,7 @@
 #include "midgard_core_workspace.h"
 #include "midgard_user.h"
 #include "sql/midgard_sql_content_manager.h"
-
-#ifdef HAVE_LIBGDA_4
 #include <sql-parser/gda-sql-parser.h>
-#endif
 
 #define MGD_MYSQL_HOST "127.0.0.1"
 #define MGD_MYSQL_DATABASE "midgard"


### PR DESCRIPTION
This condition appears to be a relic from when GDA 3 was supported. The block containing the gda_sql_parser_new function in this file used to have this GDA 4 condition as well, but [it doesn't anymore](https://github.com/midgardproject/midgard-core/commit/581404e5009a4372a1696d4785c9146bb0ad351e#diff-da9c63301e7dc484369c3a9d6100fd0a), meaning that it implicitly declares the function and converts it to a pointer when GDA 5 is used, [as can be seen here](https://launchpadlibrarian.net/229882653/buildlog_ubuntu-xenial-s390x.midgard2-core_10.05.7.1-2_BUILDING.txt.gz).
